### PR TITLE
fix(utils): gate wee_alloc global allocator on target_arch = "wasm32"

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,14 @@
 use crate::consts::*;
 use rand::{distributions::Alphanumeric, Rng, RngCore};
 
+// wee_alloc is a WASM code-size allocator that never returns freed pages to the
+// OS on native targets. Gate both the extern and the global_allocator on wasm32
+// so native builds use the system allocator (glibc malloc), which reclaims pages
+// normally and avoids unbounded RSS growth in batch pipelines.
+#[cfg(all(feature = "wee_alloc", target_arch = "wasm32"))]
 extern crate wee_alloc;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
+#[cfg(all(feature = "wee_alloc", target_arch = "wasm32"))]
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 


### PR DESCRIPTION
###   Problem
  
  wee_alloc is bound as the global allocator whenever the wee_alloc feature is enabled and that feature is on by default. 

For WebAssembly, this is fine:
  wee_alloc is deliberately minimal and optimized for code size, and WASM has no meaningful concept of "return pages to the OS" anyway. On native targets the same design becomes a liability.  wee_alloc never reclaims freed pages, by design, so under any sustained alloc/free workload the process's RSS grows monotonically.   With the previous cfg gating only on the wee_alloc feature (which is in default features), every native build using accrete's defaults silently bound wee_alloc as the global allocator.
                                                                                                                                            
This surfaced while running ~2.56M stellar systems in parallel via Rayon on a 12-core machine. The simulation completed each system correctly, but freed allocations from finished systems never returned to the OS while new systems kept allocating and eventually the process OOM-killed before the batch finished.
 
Downgrading to the system allocator on native made the leak disappear.
  
###   Change                                                                                                                                    

  Add target_arch = "wasm32" to both the extern crate wee_alloc; and the #[global_allocator] static cfg attributes, so the static is only bound on actual  WebAssembly builds. Native builds fall back to the system allocator (glibc malloc etc.), which reclaims pages normally.

###   Impact
                                                                                                                                            
  - Cargo.toml and default features are unchanged.
  - WASM behavior is unchanged:  wee_alloc is still the global allocator on a wasm32 target with default features.
  - Native builds now get the system allocator even when default features enable wee_alloc. Anyone explicitly relying on wee_alloc as the native global allocator  (an unusual configuration) would need to configure it themselves; the public API surface is otherwise unchanged.
  - Native callers who don't want any wasm-only deps compiled can still pass default-features = false as before.
