### PR TITLE
perf(system): eliminate two Planetesimal clones in planetesimals_inte…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,4 +231,13 @@ mod tests {
         let system = format!("{:?}", accrete.planet());
         assert_eq!(system, fixture);
     }
+
+    #[test]
+    fn same_seed_same_system_after_fix_3a() {
+        let mut a1 = Accrete::new(1);
+        let s1 = a1.planetary_system();
+        let mut a2 = Accrete::new(1);
+        let s2 = a2.planetary_system();
+        assert_eq!(format!("{:?}", s1), format!("{:?}", s2));
+    }
 }

--- a/src/structs/system.rs
+++ b/src/structs/system.rs
@@ -254,17 +254,27 @@ pub fn planetesimals_intersect(
     if p.is_moon {
         *prev_p = coalesce_two_planets(prev_p, p, events_log);
     } else {
-        // Check for larger/smaller planetesimal
-        let (larger, smaller) = match p.mass >= prev_p.mass {
-            true => (p.clone(), prev_p.clone()),
-            false => (prev_p.clone(), p.clone()),
+        // Compute roche_limit from scalars — avoids deep-cloning both bodies
+        // (each carries Vec<Planetesimal> moons + Vec<Ring> rings) just to read
+        // three f64s. The original code cloned `larger` and `smaller` purely to
+        // satisfy the borrow checker. Third arg to roche_limit_au is the
+        // smaller/moon body's radius (see roche_limit_au doc in utils.rs).
+        let (larger_mass, smaller_mass, smaller_radius) = if p.mass >= prev_p.mass {
+            (p.mass, prev_p.mass, prev_p.radius)
+        } else {
+            (prev_p.mass, p.mass, p.radius)
         };
-        let roche_limit = roche_limit_au(&larger.mass, &smaller.mass, &smaller.radius);
+        let roche_limit = roche_limit_au(&larger_mass, &smaller_mass, &smaller_radius);
         // Planetesimals collide or one capture another as moon
         if (prev_p.a - p.a).abs() <= roche_limit * 2.0 {
             *prev_p = coalesce_two_planets(prev_p, p, events_log);
         } else {
-            *prev_p = capture_moon(&larger, &smaller, primary_star_mass, rng, events_log);
+            // Ensure prev_p holds the larger body before capture_moon. Use
+            // `>=` to preserve the original tiebreak (p wins on equal mass).
+            if p.mass >= prev_p.mass {
+                std::mem::swap(p, prev_p);
+            }
+            *prev_p = capture_moon(prev_p, p, primary_star_mass, rng, events_log);
             prev_p
                 .moons
                 .sort_by(|p1, p2| p1.a.partial_cmp(&p2.a).unwrap());

--- a/src/structs/system.rs
+++ b/src/structs/system.rs
@@ -274,7 +274,7 @@ pub fn planetesimals_intersect(
             if p.mass >= prev_p.mass {
                 std::mem::swap(p, prev_p);
             }
-            *prev_p = capture_moon(prev_p, p, primary_star_mass, rng, events_log);
+            *prev_p = capture_moon(prev_p, p, primary_star_mass, rng, events_log.as_deref_mut());
             prev_p
                 .moons
                 .sort_by(|p1, p2| p1.a.partial_cmp(&p2.a).unwrap());


### PR DESCRIPTION
### Problem

`planetesimals_intersect` clones both `p` and `prev_p` purely to satisfy the borrow checker.  Only three scalar fields (mass, mass, radius) are ever read from the clones, to compute the Roche limit. `Planetesimal` carries `Vec<Planetesimal>` moons plus `Vec<Ring>` rings, so each clone is a deep tree copy of every captured satellite. In the post-accretion bombardment loop these clones happen per-iteration and they consumed once and dropped.

This was caught while profiling a ~2.56M-system Rayon batch on a 12-core machine. The simulation completed correctly, but the moon-tree clones were a measurable share of the per-system cost.

### Change

Replace the two clones in `planetesimals_intersect` with direct scalar extraction:

```rust
let (larger_mass, smaller_mass, smaller_radius) = if p.mass >= prev_p.mass {
    (p.mass, prev_p.mass, prev_p.radius)
} else {
    (prev_p.mass, p.mass, p.radius)
};
let roche_limit = roche_limit_au(&larger_mass, &smaller_mass, &smaller_radius);
```

Note the third argument: the original code passed `&smaller.radius`, matching `roche_limit_au`'s documented contract that the third arg is the moon (smaller) body's radius. The refactor preserves this.  Using `smaller_radius` keeps the physics bit-identical.

For the `capture_moon` call site (which previously passed `&larger, &smaller`), use `std::mem::swap` with a `>=` tiebreak to orient the bodies in place: after the swap, `prev_p` holds the larger body. This matches the original `match p.mass >= prev_p.mass { ... }` ordering exactly (`p` wins on equal mass).

A new reproducibility test (`same_seed_same_system_after_fix_3a`) is added to lock in that two successive runs at a fixed seed produce identical `Debug`-formatted output.

### Impact

- Zero behavioral change. Same Roche-limit value, same tiebreak. All 16 fixture tests pass bit-identically — no fixture regeneration needed.
- Performance: clone-elimination in the post-accretion hot loop. A private fork validated against 2.56M stellar systems attributed roughly a 15% improvement (1362s → 1159s) to this fix in isolation. That number is reference-fork data, not re-measured for this exact patch; the structural cost being eliminated is the same.
- Public API surface unchanged. No traits, public types, or function signatures altered. Single private-function refactor.